### PR TITLE
Implement Texture Asset Color Space 1.1 revision

### DIFF
--- a/Recommendations/01_TextureAssetColorSpaces/TextureAssetColorSpaces.md
+++ b/Recommendations/01_TextureAssetColorSpaces/TextureAssetColorSpaces.md
@@ -2,7 +2,7 @@
 
 **ASWF Color Interop Forum Recommendation** 
 
-*2024-10-07 v1.0 FINAL*
+*2026-06-16 v1.1.0*
 
 ### Introduction
 
@@ -62,8 +62,8 @@ The following pieces of information are provided for each color space:
 
 | Component | Description |
 | :---- | :---- |
-| Name | This is the full name of the color space. It is recommended as the user-facing text that should be used in software user interfaces. For example, these are the names that users would see in the color space menus of an application that uses OpenColorIO. |
-| Compact Name | This is a shorter name that is intended to be used in file formats. These are constructed so that they are also suitable for use in file paths or as arguments to command-line tools or scripts. In the context of OpenColorIO, these are referred to as "aliases" for the full name but do not appear in user-facing menus. |
+| Name | This is the full name of the color space. It is recommended as the user-facing text that should be used in software user interfaces. For example, these are the names that users would see in the color space menus of an application that uses the OpenColorIO configs for ACES. |
+| Color Interop ID | This is a compact name that is intended to be used in file formats. These are constructed so that they are also suitable for use in file paths or as arguments to command-line tools or scripts. In the context of OpenColorIO, these are "aliases" for the full name and should not appear in user-facing menus. Please see the Recommendation "An ID for Color Interop" for details.|
 | Transfer Function | The transfer function is the non-linearity that is applied to the RGB values relative to a linear representation. Values are described as "linear" if they are proportional to light energy in the scene. A doubling of a linear value is equivalent to an increase of one photographic "stop". For non-linear transfer functions, the description provided is for the function to convert the non-linear encoding to a linear encoding (i.e., the EOTF). |
 | Primaries | The color primaries are the CIE 1931 xy chromaticity coordinates for red, green, and blue. The linear RGB values are tristimulus values in the specified coordinates. Positive RGB values define the gamut for those primaries. Note that since the linear color spaces are expected to be represented using floating-point numbers, colors outside the gamut of the primaries may be represented using a negative value for one or more of R, G, or B. However, since negative values tend to be problematic in CG rendering calculations, it is customary to only use positive values. |
 | White Point | The CIE 1931 xy chromaticity coordinates that the primaries are normalized to. This defines the white point of the viewing environment that the observer is adapted to. |
@@ -75,32 +75,34 @@ The following pieces of information are provided for each color space:
 
 ## Color Space Recommendations for Texture Assets and CG Rendering
 
-#### Summary Table — Overview of the Recommendations
+#### Summary Table — Overview of the Recommendation
 
-| Name | Compact Name | Transfer Function | Primaries | White Point | Image State |
+| Name | Interop ID | Transfer Function | Primaries | White Point | Image State |
 | :---- | :---- | :---- | :---- | :---- | :---- |
-| ACEScg | lin\_ap1\_scene | Linear | AP1 | D60 | Scene-referred |
-| ACES2065-1 | lin\_ap0\_scene | Linear | AP0 | D60 | Scene-referred |
-| Linear Rec.709 (sRGB) | lin\_rec709\_scene | Linear | Rec.709 | D65 | Scene-referred |
-| Linear P3-D65 | lin\_p3d65\_scene | Linear | DCI-P3 | D65 | Scene-referred |
-| Linear Rec.2020 | lin\_rec2020\_scene | Linear | Rec.2020 | D65 | Scene-referred |
-| Linear AdobeRGB | lin\_adobergb\_scene | Linear | AdobeRGB | D65 | Scene-referred |
-| CIE XYZ-D65 \- Scene-referred | lin\_ciexyzd65\_scene | Linear | XYZ 1931 | D65 | Scene-referred |
-| sRGB Encoded Rec.709 (sRGB) | srgb\_rec709\_scene | sRGB | Rec.709 | D65 | Scene-referred |
-| Gamma 2.2 Encoded Rec.709 | g22\_rec709\_scene | 2.2 power | Rec.709 | D65 | Scene-referred |
-| Gamma 1.8 Encoded Rec.709 | g18\_rec709\_scene | 1.8 power | Rec.709 | D65 | Scene-referred |
-| sRGB Encoded AP1 | srgb\_ap1\_scene | sRGB | AP1 | D60 | Scene-referred |
-| Gamma 2.2 Encoded AP1 | g22\_ap1\_scene | 2.2 power | AP1 | D60 | Scene-referred |
-| sRGB Encoded P3-D65 | srgb\_p3d65\_scene | sRGB | DCI-P3 | D65 | Scene-referred |
-| Gamma 2.2 Encoded AdobeRGB | g22\_adobergb\_scene | \~2.2 power | AdobeRGB | D65 | Scene-referred |
-| Data | data | n/a | n/a | n/a | n/a |
-| Unknown | unknown | n/a | n/a | n/a | n/a |
+| ACEScg | `lin_ap1_scene` | Linear | AP1 | D60 | Scene-referred |
+| ACES2065-1 | `lin_ap0_scene` | Linear | AP0 | D60 | Scene-referred |
+| Linear Rec.709 (sRGB) | `lin_rec709_scene` | Linear | Rec.709 | D65 | Scene-referred |
+| Linear P3-D65 | `lin_p3d65_scene` | Linear | DCI-P3 | D65 | Scene-referred |
+| Linear Rec.2020 | `lin_rec2020_scene` | Linear | Rec.2020 | D65 | Scene-referred |
+| Linear AdobeRGB | `lin_adobergb_scene` | Linear | AdobeRGB | D65 | Scene-referred |
+| CIE XYZ-D65 - Scene-referred | `lin_ciexyzd65_scene` | Linear | XYZ 1931 | D65 | Scene-referred |
+| sRGB Encoded Rec.709 (sRGB) | `srgb_rec709_scene` | sRGB | Rec.709 | D65 | Scene-referred |
+| Gamma 2.4 Encoded Rec.709 | `g24_rec709_scene` | 2.4 power | Rec.709 | D65 | Scene-referred |
+| Gamma 2.2 Encoded Rec.709 | `g22_rec709_scene` | 2.2 power | Rec.709 | D65 | Scene-referred |
+| Gamma 1.8 Encoded Rec.709 | `g18_rec709_scene` | 1.8 power | Rec.709 | D65 | Scene-referred |
+| sRGB Encoded AP1 | `srgb_ap1_scene` | sRGB | AP1 | D60 | Scene-referred |
+| Gamma 2.2 Encoded AP1 | `g22_ap1_scene` | 2.2 power | AP1 | D60 | Scene-referred |
+| sRGB Encoded P3-D65 | `srgb_p3d65_scene` | sRGB | DCI-P3 | D65 | Scene-referred |
+| Gamma 2.2 Encoded AdobeRGB | `g22_adobergb_scene` | \~2.2 power | AdobeRGB | D65 | Scene-referred |
+| Data | `data` | n/a | n/a | n/a | n/a |
+| Unknown | `unknown` | n/a | n/a | n/a | n/a |
+| Bypass | `bypass` | n/a | n/a | n/a | n/a |
 
 #### Linear Color Space Encodings
 
 | Name | ACEScg |
 | :---- | :---- |
-| Compact Name | lin\_ap1\_scene |
+| Interop ID | `lin_ap1_scene` |
 | Transfer Function | Linear |
 | Primaries | AP1 – R {x: 0.713, y: 0.293}, G {x: 0.165, y: 0.830}, B {x: 0.128, y: 0.044} |
 | White Point | D60 – {x: 0.32168, y: 0.33767} |
@@ -112,7 +114,7 @@ The following pieces of information are provided for each color space:
 
 | Name | ACES2065-1 |
 | :---- | :---- |
-| Compact Name | lin\_ap0\_scene |
+| Interop ID | `lin_ap0_scene` |
 | Transfer Function | Linear |
 | Primaries | AP0 – R {x: 0.7347, y: 0.2653}, G {x: 0.0, y: 1.0}, B {x: 0.0001, y: –0.0770} |
 | White Point | D60 – {x: 0.32168, y: 0.33767} |
@@ -124,7 +126,7 @@ The following pieces of information are provided for each color space:
 
 | Name | Linear Rec.709 (sRGB) |
 | :---- | :---- |
-| Compact Name | lin\_rec709\_scene |
+| Interop ID | `lin_rec709_scene` |
 | Transfer Function | Linear |
 | Primaries | Rec.709 – R {x: 0.640, y: 0.330}, G {x: 0.300, y: 0.600}, B {x: 0.150, y: 0.060} |
 | White Point | D65 – {x: 0.3127, y: 0.3290} |
@@ -136,7 +138,7 @@ The following pieces of information are provided for each color space:
 
 | Name | Linear P3-D65 |
 | :---- | :---- |
-| Compact Name | lin\_p3d65\_scene |
+| Interop ID | `lin_p3d65_scene` |
 | Transfer Function | Linear |
 | Primaries | DCI-P3 – R {x: 0.680, y: 0.320}, G {x: 0.265, y: 0.690}, B {x: 0.150, y: 0.060} |
 | White Point | D65 – {x: 0.3127, y: 0.3290} |
@@ -148,7 +150,7 @@ The following pieces of information are provided for each color space:
 
 | Name | Linear Rec.2020 |
 | :---- | :---- |
-| Compact Name | lin\_rec2020\_scene |
+| Interop ID | `lin_rec2020_scene` |
 | Transfer Function | Linear |
 | Primaries | Rec.2020 – R {x: 0.708, y: 0.292}, G {x: 0.170, y: 0.797}, B {x: 0.131, y: 0.046} |
 | White Point | D65 – {x: 0.3127, y: 0.3290} |
@@ -160,7 +162,7 @@ The following pieces of information are provided for each color space:
 
 | Name | Linear AdobeRGB |
 | :---- | :---- |
-| Compact Name | lin\_adobergb\_scene |
+| Interop ID | `lin_adobergb_scene` |
 | Transfer Function | Linear |
 | Primaries | AdobeRGB – R {x: 0.640, y: 0.330}, G {x: 0.210, y: 0.710}, B {x: 0.150, y: 0.060} |
 | White Point | D65 – {x: 0.3127, y: 0.3290} |
@@ -172,7 +174,7 @@ The following pieces of information are provided for each color space:
 
 | Name | CIE XYZ-D65 \- Scene-referred |
 | :---- | :---- |
-| Compact Name | lin\_ciexyzd65\_scene |
+| Interop ID | `lin_ciexyzd65_scene` |
 | Transfer Function | Linear |
 | Primaries | CIE XYZ 1931 – R {x:1., y:0.}, G {x:0., y:1.}, B {x:0., y:0.} |
 | White Point | D65 – {x: 0.3127, y: 0.3290} |
@@ -186,7 +188,7 @@ The following pieces of information are provided for each color space:
 
 | Name | sRGB Encoded Rec.709 (sRGB) |
 | :---- | :---- |
-| Compact Name | srgb\_rec709\_scene |
+| Interop ID | `srgb_rec709_scene` |
 | Transfer Function | sRGB (piecewise) |
 | Primaries | Rec.709 – R {x: 0.640, y: 0.330}, G {x: 0.300, y: 0.600}, B {x: 0.150, y: 0.060} |
 | White Point | D65 – {x: 0.3127, y: 0.3290} |
@@ -196,9 +198,21 @@ The following pieces of information are provided for each color space:
 | Notes | This is a scene-referred version of the sRGB color space. Please see Annex B for details. |
 | References | https://www.colour-science.org/posts/srgb-eotf-pure-gamma-22-or-piece-wise-function/ <br><br> IEC 61966-2-1:1999 |
 
+| Name | Gamma 2.4 Encoded Rec.709 |
+| :---- | :---- |
+| Interop ID | `g24_rec709_scene` |
+| Transfer Function | Power function with exponent: 2.4 |
+| Primaries | Rec.709 – R {x: 0.640, y: 0.330}, G {x: 0.300, y: 0.600}, B {x: 0.150, y: 0.060} |
+| White Point | D65 – {x: 0.3127, y: 0.3290} |
+| Image State | Scene-referred |
+| Rendering Space | No |
+| Basic | No |
+| Notes | Although this is mathematically similar to the transform for a Rec.1886/Rec.709 monitor, this color space is scene-referred. For the actual standard, display-referred color space, please see `g24_rec709_display` in the recommendation "Color Space Encodings for Displays." |
+| References | There is no color space encoding specification, but the primaries may be found in: https://www.itu.int/rec/R-REC-BT.709 |
+
 | Name | Gamma 2.2 Encoded Rec.709 |
 | :---- | :---- |
-| Compact Name | g22\_rec709\_scene |
+| Interop ID | `g22_rec709_scene` |
 | Transfer Function | Power function with exponent: 2.2 |
 | Primaries | Rec.709 – R {x: 0.640, y: 0.330}, G {x: 0.300, y: 0.600}, B {x: 0.150, y: 0.060} |
 | White Point | D65 – {x: 0.3127, y: 0.3290} |
@@ -210,7 +224,7 @@ The following pieces of information are provided for each color space:
 
 | Name | Gamma Encoded 1.8 Rec.709 |
 | :---- | :---- |
-| Compact Name | g18\_rec709\_scene |
+| Interop ID | `g18_rec709_scene` |
 | Transfer Function | Power function with exponent: 1.8 |
 | Primaries | Rec.709 – R {x: 0.640, y: 0.330}, G {x: 0.300, y: 0.600}, B {x: 0.150, y: 0.060} |
 | White Point | D65 – {x: 0.3127, y: 0.3290} |
@@ -222,7 +236,7 @@ The following pieces of information are provided for each color space:
 
 | Name | sRGB Encoded AP1 |
 | :---- | :---- |
-| Compact Name | srgb\_ap1\_scene |
+| Interop ID | `srgb_ap1_scene` |
 | Transfer Function | sRGB (piecewise) |
 | Primaries | AP1 – R {x: 0.713, y: 0.293}, G {x: 0.165, y: 0.830}, B {x: 0.128, y: 0.044} |
 | White Point | D60 – {x: 0.32168, y: 0.33767} |
@@ -234,7 +248,7 @@ The following pieces of information are provided for each color space:
 
 | Name | Gamma Encoded 2.2 AP1 |
 | :---- | :---- |
-| Compact Name | g22\_ap1\_scene |
+| Interop ID | `g22_ap1_scene` |
 | Transfer Function | Power function with exponent: 2.2 |
 | Primaries | AP1 – R {x: 0.713, y: 0.293}, G {x: 0.165, y: 0.830}, B {x: 0.128, y: 0.044} |
 | White Point | D60 – {x: 0.32168, y: 0.33767} |
@@ -246,7 +260,7 @@ The following pieces of information are provided for each color space:
 
 | Name | sRGB Encoded P3-D65 |
 | :---- | :---- |
-| Compact Name | srgb\_p3d65\_scene |
+| Interop ID | `srgb_p3d65_scene` |
 | Transfer Function | sRGB (piecewise) |
 | Primaries | DCI-P3 – R {x: 0.680, y: 0.320}, G {x: 0.265, y: 0.690}, B {x: 0.150, y: 0.060} |
 | White Point | D65 – {x: 0.3127, y: 0.3290} |
@@ -258,7 +272,7 @@ The following pieces of information are provided for each color space:
 
 | Name | Gamma 2.2 Encoded AdobeRGB |
 | :---- | :---- |
-| Compact Name | g22\_adobergb\_scene |
+| Interop ID | `g22_adobergb_scene` |
 | Transfer Function | Power function with exponent: 563 / 256 |
 | Primaries | AdobeRGB – R {x: 0.640, y: 0.330}, G {x: 0.210, y: 0.710}, B {x: 0.150, y: 0.060} |
 | White Point | D65 – {x: 0.3127, y: 0.3290} |
@@ -272,19 +286,19 @@ The following pieces of information are provided for each color space:
 
 | Name | Data |
 | :---- | :---- |
-| Compact Name | data |
+| Interop ID | `data` |
 | Transfer Function | n/a |
 | Primaries | n/a |
 | White Point | n/a |
 | Image State | n/a |
 | Rendering Space | No |
 | Basic | Yes |
-| Notes | This "color space" designation indicates that the asset it describes is actually not color data. For example, image file formats are often used to represent data such as normal maps which should not have any color conversions applied to them. A color space designation of "data" is an indication to the color management system that no conversion should be performed. <br><br> Alpha or matte values are not colors. If an image of alpha values is stored on its own, it would be appropriate to label it as "data". However, if data is stored in RGBA form, the color space designation should be interpreted as only applying to the RGB part. The A part should be handled as if it were labeled "data". |
+| Notes | This "color space" designation indicates that the asset it describes is actually not color data. For example, image file formats are often used to represent data such as normal maps which should not have any color conversions applied to them. A color space designation of `data` is an indication to the color management system that no conversion should be performed. <br><br> Alpha or matte values are not colors. If an image of alpha values is stored on its own, it would be appropriate to label it as `data`. However, if data is stored in RGBA form, the color space designation should be interpreted as only applying to the RGB part. The A part should be handled as if it were labeled `data`. |
 | References |  |
 
 | Name | Unknown |
 | :---- | :---- |
-| Compact Name | unknown |
+| Interop ID | `unknown` |
 | Transfer Function | n/a |
 | Primaries | n/a |
 | White Point | n/a |
@@ -292,6 +306,18 @@ The following pieces of information are provided for each color space:
 | Rendering Space | No |
 | Basic | No |
 | Notes | One of the anticipated primary uses of these recommendations is as values to set for the "color space" field in various file formats. Often such metadata is unreliable because software assigns an inaccurate color space as a default value. Therefore, it is essential that any set of color space designators provide a value that software developers may use to indicate that the true color space of the given asset is not known. |
+| References |  |
+
+| Name | Bypass |
+| :---- | :---- |
+| Interop ID | `bypass` |
+| Transfer Function | n/a |
+| Primaries | n/a |
+| White Point | n/a |
+| Image State | n/a |
+| Rendering Space | No |
+| Basic | No |
+| Notes | This designation is intended to support workflows where it is desired to defer tagging the image with its actual color space. This is different from `unknown` in that, whereas applications may write `unknown` if the color space is not known, an application should only write `bypass` if instructed to do so by an end-user. In other words, `bypass` is more of an intentional statement to delay color space assignment and this may be handled by downstream applications differently than `unknown`. |
 | References |  |
 
 ## Annexes
@@ -343,17 +369,17 @@ The EOTF transfer function then becomes:
     else
         out = pow((in + k) / (1. + k), g)
 
-### Annex C: Structure of the Compact Names
+### Annex C: Structure of the Color Interop ID Names
 
-The compact names were the subject of intense discussion during Color Interop Forum meetings. The result is a compromise which tries to balance many different requirements and opinions. The structure uses an "analytical" approach that includes three components: the transfer function, the gamut (or primaries), and the image state.
+These compact names were the subject of intense discussion during Color Interop Forum meetings. The result is a compromise which tries to balance many different requirements and opinions. The structure uses an "analytical" approach that includes three components: the transfer function, the gamut (or primaries), and the image state.
 
 White point is another aspect that was discussed by the working group. However, in the interest of trying to keep the names more compact, it was decided not to have a separate analytic component for the adaptive white point because the standards for the primaries typically have an associated white point. It is therefore omitted from most of the names (where the white point is essentially communicated via the primaries) and only added to the gamut component of the name where it would otherwise be ambiguous.
 
 The transfer function was put first since this is the structure that was already being used in the OCIO configs for ACES, which in turn was influenced by the ACES system where digital cinema camera names followed this form. This ordering is also what has been used in the MaterialX specification. 
 
-Although all of the color space encodings defined in the present document are scene-referred, the plan is to add additional recommendations that would include display-referred color spaces. Thus, it is essential to have a way to disambiguate identical mathematical representations that appear with both image states. For example, once the full list has been produced, there will be both an "srgb\_rec709\_scene" and a "srgb\_rec709\_display". Moreover, given that the OCIO configs for ACES currently have both versions, the need for both exists already on the OCIO side.
+Although all of the color space encodings defined in the present document are scene-referred, the plan was to add additional recommendations that would include display-referred color spaces (this has now been done). Thus, it is essential to have a way to disambiguate identical mathematical representations that appear with both image states. For example, across the various recommendations, there is both an `srgb_rec709_scene` and an `srgb_rec709_display`. Moreover, given that the OCIO configs for ACES currently have both versions, the need for both exists already on the OCIO side.
 
-Finally, the goal is that the compact names will become keywords in OpenColorIO that will not be possible to override, so there was a desire to avoid collision with certain frequently used names.
+Finally, the goal is that eventually the Interop IDs may become keywords in OpenColorIO that will not be possible to override, so there was a desire to avoid collision with certain frequently used names.
 
 ### Annex D: OCIO Reference Config
 
@@ -367,8 +393,19 @@ The MatrixTransform in OCIO is a 4x4 matrix, converting RGBA to RGBA. The orderi
 
 More detail about OCIO config files is available from the opencolorio.org website.
 
+### Annex E: Revision History
+
+| Date | Version | Notes |
+| :---- | :---- | :---- |
+|2024-10-07 | 1.0.0 | Initial release |
+|2026-06-16 | 1.1.0 | Add `g24_rec709_scene` and `bypass`. Harmonize terminology with other recommendations. |
+
 
 ## General References
+
+Color Interop Forum Recommendation ["Color Space Encodings for Displays"](https://github.com/AcademySoftwareFoundation/ColorInterop/blob/main/Recommendations/02_DisplayColorSpaces/DisplayColorSpaces.md)
+
+Color Interop Forum: [An ID for Color Interop](https://github.com/AcademySoftwareFoundation/ColorInterop/blob/main/Recommendations/03_ColorInteropID/ColorInteropID.md)
 
 ISO 22028-1:2016 Photography and graphic technology — Extended colour encodings for digital image storage, manipulation and interchange, Part 1: Architecture and requirements  
 https://www.iso.org/standard/68761.html

--- a/Recommendations/01_TextureAssetColorSpaces/core-renderer-config.ocio
+++ b/Recommendations/01_TextureAssetColorSpaces/core-renderer-config.ocio
@@ -5,10 +5,10 @@ environment:
 search_path: ""
 strictparsing: false
 luma: [0.2126, 0.7152, 0.0722]
-name: core-renderer-config-v1.0.0
+name: core-renderer-config-v1.1.0
 description: |
   Color Space Encodings for Texture Assets and CG Rendering
-  ASWF Color Interop Forum Recommendation 2024-10
+  ASWF Color Interop Forum Recommendation v1.1 2026-07
 
 roles:
   aces_interchange: ACES2065-1
@@ -29,6 +29,7 @@ colorspaces:
   - !<ColorSpace>
     name: ACES2065-1
     aliases: [lin_ap0_scene]
+    interop_id: lin_ap0_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -41,6 +42,7 @@ colorspaces:
   - !<ColorSpace>
     name: ACEScg
     aliases: [lin_ap1_scene]
+    interop_id: lin_ap1_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -50,11 +52,12 @@ colorspaces:
     allocation: uniform
     to_scene_reference: !<GroupTransform>
       children:
-        - !<MatrixTransform> {matrix: [0.695452241357452, 0.140678696470294, 0.163869062172254, 0, 0.0447945633720377, 0.859671118456422, 0.0955343181715404, 0, -0.00552588255811355, 0.00402521030597869, 1.00150067225214, 0, 0, 0, 0, 1]}
+        - !<MatrixTransform> {matrix: [0.695452241357452, 0.140678696470294, 0.163869062172254, 0, 0.0447945633720378, 0.859671118456422, 0.0955343181715404, 0, -0.00552588255811354, 0.00402521030597867, 1.00150067225213, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
     name: Linear Rec.709 (sRGB)
     aliases: [lin_rec709_scene]
+    interop_id: lin_rec709_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -64,11 +67,12 @@ colorspaces:
     allocation: uniform
     to_scene_reference: !<GroupTransform>
       children:
-        - !<MatrixTransform> {matrix: [0.439632981919491, 0.382988698151554, 0.177378319928955, 0, 0.0897764429588424, 0.813439428748981, 0.0967841282921771, 0, 0.0175411703831727, 0.111546553302387, 0.87091227631444, 0, 0, 0, 0, 1]}
+        - !<MatrixTransform> {matrix: [0.439632981919491, 0.382988698151554, 0.177378319928955, 0, 0.0897764429588423, 0.813439428748981, 0.096784128292177, 0, 0.0175411703831727, 0.111546553302387, 0.87091227631444, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
     name: Linear P3-D65
     aliases: [lin_p3d65_scene]
+    interop_id: lin_p3d65_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -83,6 +87,7 @@ colorspaces:
   - !<ColorSpace>
     name: Linear Rec.2020
     aliases: [lin_rec2020_scene]
+    interop_id: lin_rec2020_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -92,11 +97,12 @@ colorspaces:
     allocation: uniform
     to_scene_reference: !<GroupTransform>
       children:
-        - !<MatrixTransform> {matrix: [0.679085634706912, 0.157700914643159, 0.163213450649929, 0, 0.0460020030800595, 0.859054673002908, 0.0949433239170327, 0, -0.000573943187616196, 0.0284677684080264, 0.97210617477959, 0, 0, 0, 0, 1]}
+        - !<MatrixTransform> {matrix: [0.679085634706912, 0.157700914643159, 0.163213450649929, 0, 0.0460020030800594, 0.859054673002908, 0.0949433239170326, 0, -0.000573943187616196, 0.0284677684080264, 0.97210617477959, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
     name: Linear AdobeRGB
     aliases: [lin_adobergb_scene]
+    interop_id: lin_adobergb_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -106,11 +112,12 @@ colorspaces:
     allocation: uniform
     to_scene_reference: !<GroupTransform>
       children:
-        - !<MatrixTransform> {matrix: [0.614763305501725, 0.200243702572018, 0.184992991926256, 0, 0.125539404683864, 0.773521622216629, 0.100938973099507, 0, 0.0245287963611042, 0.0671715435381276, 0.908299660100768, 0, 0, 0, 0, 1]}
+        - !<MatrixTransform> {matrix: [0.614763305501725, 0.200243702572018, 0.184992991926257, 0, 0.125539404683864, 0.773521622216629, 0.100938973099507, 0, 0.0245287963611042, 0.0671715435381276, 0.908299660100768, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
     name: CIE XYZ-D65 - Scene-referred
     aliases: [lin_ciexyzd65_scene]
+    interop_id: lin_ciexyzd65_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -119,11 +126,12 @@ colorspaces:
     allocation: uniform
     to_scene_reference: !<GroupTransform>
       children:
-        - !<MatrixTransform> {matrix: [1.0634954914942, 0.00640891019711789, -0.0158067866176054, 0, -0.492074127923892, 1.36822340747333, 0.0913370883144736, 0, -0.00281646163925351, 0.00464417105680067, 0.916418574593656, 0, 0, 0, 0, 1]}
+        - !<MatrixTransform> {matrix: [1.0634954914942, 0.00640891019711777, -0.0158067866176054, 0, -0.492074127923892, 1.36822340747333, 0.0913370883144736, 0, -0.00281646163925351, 0.00464417105680067, 0.916418574593656, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
     name: sRGB Encoded Rec.709 (sRGB)
     aliases: [srgb_rec709_scene]
+    interop_id: srgb_rec709_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -134,11 +142,28 @@ colorspaces:
     to_scene_reference: !<GroupTransform>
       children:
         - !<ExponentWithLinearTransform> {gamma: 2.4, offset: 0.055}
-        - !<MatrixTransform> {matrix: [0.439632981919491, 0.382988698151554, 0.177378319928955, 0, 0.0897764429588424, 0.813439428748981, 0.0967841282921771, 0, 0.0175411703831727, 0.111546553302387, 0.87091227631444, 0, 0, 0, 0, 1]}
+        - !<MatrixTransform> {matrix: [0.439632981919491, 0.382988698151554, 0.177378319928955, 0, 0.0897764429588423, 0.813439428748981, 0.096784128292177, 0, 0.0175411703831727, 0.111546553302387, 0.87091227631444, 0, 0, 0, 0, 1]}
+
+  - !<ColorSpace>
+    name: Gamma 2.4 Encoded Rec.709
+    aliases: [g24_rec709_scene]
+    interop_id: g24_rec709_scene
+    family: ""
+    equalitygroup: ""
+    bitdepth: 32f
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    to_scene_reference: !<GroupTransform>
+      children:
+        - !<ExponentTransform> {value: 2.4, style: pass_thru}
+        - !<MatrixTransform> {matrix: [0.439632981919491, 0.382988698151554, 0.177378319928955, 0, 0.0897764429588423, 0.813439428748981, 0.096784128292177, 0, 0.0175411703831727, 0.111546553302387, 0.87091227631444, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
     name: Gamma 2.2 Encoded Rec.709
     aliases: [g22_rec709_scene]
+    interop_id: g22_rec709_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -149,11 +174,12 @@ colorspaces:
     to_scene_reference: !<GroupTransform>
       children:
         - !<ExponentTransform> {value: 2.2, style: pass_thru}
-        - !<MatrixTransform> {matrix: [0.439632981919491, 0.382988698151554, 0.177378319928955, 0, 0.0897764429588424, 0.813439428748981, 0.0967841282921771, 0, 0.0175411703831727, 0.111546553302387, 0.87091227631444, 0, 0, 0, 0, 1]}
+        - !<MatrixTransform> {matrix: [0.439632981919491, 0.382988698151554, 0.177378319928955, 0, 0.0897764429588423, 0.813439428748981, 0.096784128292177, 0, 0.0175411703831727, 0.111546553302387, 0.87091227631444, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
     name: Gamma 1.8 Encoded Rec.709
     aliases: [g18_rec709_scene]
+    interop_id: g18_rec709_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -164,11 +190,12 @@ colorspaces:
     to_scene_reference: !<GroupTransform>
       children:
         - !<ExponentTransform> {value: 1.8, style: pass_thru}
-        - !<MatrixTransform> {matrix: [0.439632981919491, 0.382988698151554, 0.177378319928955, 0, 0.0897764429588424, 0.813439428748981, 0.0967841282921771, 0, 0.0175411703831727, 0.111546553302387, 0.87091227631444, 0, 0, 0, 0, 1]}
+        - !<MatrixTransform> {matrix: [0.439632981919491, 0.382988698151554, 0.177378319928955, 0, 0.0897764429588423, 0.813439428748981, 0.096784128292177, 0, 0.0175411703831727, 0.111546553302387, 0.87091227631444, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
     name: sRGB Encoded AP1
     aliases: [srgb_ap1_scene]
+    interop_id: srgb_ap1_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -179,11 +206,12 @@ colorspaces:
     to_scene_reference: !<GroupTransform>
       children:
         - !<ExponentWithLinearTransform> {gamma: 2.4, offset: 0.055}
-        - !<MatrixTransform> {matrix: [0.695452241357452, 0.140678696470294, 0.163869062172254, 0, 0.0447945633720377, 0.859671118456422, 0.0955343181715404, 0, -0.00552588255811355, 0.00402521030597869, 1.00150067225214, 0, 0, 0, 0, 1]}
+        - !<MatrixTransform> {matrix: [0.695452241357452, 0.140678696470294, 0.163869062172254, 0, 0.0447945633720378, 0.859671118456422, 0.0955343181715404, 0, -0.00552588255811354, 0.00402521030597867, 1.00150067225213, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
     name: Gamma 2.2 Encoded AP1
     aliases: [g22_ap1_scene]
+    interop_id: g22_ap1_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -194,11 +222,12 @@ colorspaces:
     to_scene_reference: !<GroupTransform>
       children:
         - !<ExponentTransform> {value: 2.2, style: pass_thru}
-        - !<MatrixTransform> {matrix: [0.695452241357452, 0.140678696470294, 0.163869062172254, 0, 0.0447945633720377, 0.859671118456422, 0.0955343181715404, 0, -0.00552588255811355, 0.00402521030597869, 1.00150067225214, 0, 0, 0, 0, 1]}
+        - !<MatrixTransform> {matrix: [0.695452241357452, 0.140678696470294, 0.163869062172254, 0, 0.0447945633720378, 0.859671118456422, 0.0955343181715404, 0, -0.00552588255811354, 0.00402521030597867, 1.00150067225213, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
     name: sRGB Encoded P3-D65
     aliases: [srgb_p3d65_scene]
+    interop_id: srgb_p3d65_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -214,6 +243,7 @@ colorspaces:
   - !<ColorSpace>
     name: Gamma 2.2 Encoded AdobeRGB
     aliases: [g22_adobergb_scene]
+    interop_id: g22_adobergb_scene
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -224,11 +254,12 @@ colorspaces:
     to_scene_reference: !<GroupTransform>
       children:
         - !<ExponentTransform> {value: 2.19921875, style: pass_thru}
-        - !<MatrixTransform> {matrix: [0.614763305501725, 0.200243702572018, 0.184992991926256, 0, 0.125539404683864, 0.773521622216629, 0.100938973099507, 0, 0.0245287963611042, 0.0671715435381276, 0.908299660100768, 0, 0, 0, 0, 1]}
+        - !<MatrixTransform> {matrix: [0.614763305501725, 0.200243702572018, 0.184992991926257, 0, 0.125539404683864, 0.773521622216629, 0.100938973099507, 0, 0.0245287963611042, 0.0671715435381276, 0.908299660100768, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
     name: Data
     aliases: [Raw]
+    interop_id: data
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -239,6 +270,7 @@ colorspaces:
 
   - !<ColorSpace>
     name: Unknown
+    interop_id: unknown
     family: ""
     equalitygroup: ""
     bitdepth: 32f
@@ -246,3 +278,14 @@ colorspaces:
     isdata: false
     allocation: uniform
     to_scene_reference: !<ColorSpaceTransform> {src: srgb_rec709_scene, dst: lin_ap0_scene}
+
+  - !<ColorSpace>
+    name: Bypass
+    interop_id: bypass
+    family: ""
+    equalitygroup: ""
+    bitdepth: 32f
+    isdata: true
+    categories: [file-io]
+    encoding: data
+    allocation: uniform


### PR DESCRIPTION
The following updates are made:
- Add a "bypass" interop ID following up on [this proposal](https://github.com/AcademySoftwareFoundation/ColorInterop/issues/15).
- Add a "g24_rec709_scene" ID. 
- Use "Interop ID" rather than "Compact Name" to adopt the terminology used in later recommendations in the series. (That term had not been coined at the time the first version was written.)
- Bump the version number of the specification to 1.1.
- Add the interop ID and display color space recommendations to the references section.
- Updated the config file to add the new color spaces and add the interop_id.
- Add a revision history as Annex E.

The addition of "g24_rec709_scene" is to respond to the fact that it has [recently been added to OpenUSD](https://github.com/PixarAnimationStudios/OpenUSD/commit/fce2189f904c844b42586515035dcc9f6fed156c). 

While not currently listed as one of the allowed MaterialX color spaces on the [main documentation page](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md#color-spaces-and-color-management-systems), "rec709_display" (which is mathematically equivalent) does appear in [other areas of the documentation](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/libraries#target-support) and historically was one of the allowed color spaces. It is currently supported by both the MaterialX [default color manager](https://github.com/AcademySoftwareFoundation/MaterialX/blob/ccaf60788b034b59270b1e0dea86658d7479d74a/libraries/cmlib/cmlib_ng.mtlx#L70) and OCIO color manager (if using the built-in OCIO configs, which already contain this color space). Hence, it will likely need to be supported indefinitely for backwards compatibility.

While a gamma 2.4 Rec.709 scene-referred space is not widely used, _or even recommended_, the fact that OpenUSD and MaterialX may produce files tagged with that, implies that it needs to be in the CIF recommendation since it will be an interop problem otherwise.